### PR TITLE
matchMz performance improvement and parameter renaming

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboAnnotation
 Title: Utilities for Annotation of Metabolomics Data
-Version: 0.2.4
+Version: 0.2.5
 Description:
     High level functions to assist in annotation of (metabolomics) data sets.
     These include functions to perform simple tentative annotations based on

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # MetaboAnnotation 0.2
 
+## Changes in 0.2.5
+
+- Improve performance of `matchMz`.
+- Rename `queryColumn` and `targetColumn` to `queryColname` and `targetColname`.
+
 ## Changes in 0.2.4
 
 - Support `data.frame`, `DataFrame` and `matrix` in `matchMz`.

--- a/R/Matched.R
+++ b/R/Matched.R
@@ -46,8 +46,8 @@
 #'   both `queryValue` and `targetValue` are considered to be integer indices
 #'   identifying the matching elements in `query` and `target`, respectively.
 #'   Alternatively (with `isIndex = FALSE`) `queryValue` and `targetValue` can
-#'   be elements in columns `queryColumn` or `targetColumn` which can be used to
-#'   identify the matching elements. Note that in this case
+#'   be elements in columns `queryColname` or `targetColname` which can be used
+#'   to identify the matching elements. Note that in this case
 #'   **only the first** matching pair is added. Parameter `score` allows to
 #'   provide the score for the match. It can be a numeric with the score or a
 #'   `data.frame` with additional information on the manually added matches. In
@@ -150,7 +150,7 @@
 #' @param targetValue for `filterMatches`: vector of values to search for in
 #'   `target` (if `target` is 1-dimensional) or in column `targetColname` of
 #'   `target` (if `target` is 2-dimensional). For `addMatches`: either an
-#'   index in `target` or value in column `targetColumn` of `target` defining
+#'   index in `target` or value in column `targetColname` of `target` defining
 #'   (together with `queryValue`) the pair of query and target elements for
 #'   which a match should be manually added. Lengths of `queryValue` and
 #'   `targetValue` have to match.
@@ -163,7 +163,7 @@
 #' @param queryValue for `filterMatches`: vector of values to search for in
 #'   `query` (if `query` is 1-dimensional) or in column `queryColname` of
 #'   `query` (if `query` is 2-dimensional). For `addMatches`: either an index
-#'   in `query` or value in column `queryColumn` of `query` defining (together
+#'   in `query` or value in column `queryColname` of `query` defining (together
 #'   with `targetValue`) the pair of query and target elements for which a
 #'   match should be manually added. Lengths of `queryValue` and
 #'   `targetValue` have to match.

--- a/R/matchMz.R
+++ b/R/matchMz.R
@@ -122,11 +122,11 @@ MzRtParam <- function(tolerance = 0, ppm = 0, toleranceRt = 0) {
 #'   from the mass of the compounds in the *target* table for the specified
 #'   adducts (parameter `adduct` in the parameter object).
 #'   `query` must be a `data.frame` with a column containing m/z values (column
-#'   name can be specified with parameter `mzColumn` which defaults to `"mz"`)
+#'   name can be specified with parameter `mzColname` which defaults to `"mz"`)
 #'   or a `numeric` with the m/z values of the features.
 #'   If `target` is a `data.frame` it must
 #'   contain a column with the (monoisotopic) mass of the compounds (the column
-#'   name can be specified with parameter `massColumn` which defaults to
+#'   name can be specified with parameter `massColname` which defaults to
 #'   `"exactmass"`) `Mass2MzParam`'s parameter `adducts` allows to define
 #'   the expected adducts (defaults to `adducts = "[M+H]+"` but any adducts
 #'   available in [MetaboCoreUtils::adducts()] are supported). Parameter
@@ -141,11 +141,11 @@ MzRtParam <- function(tolerance = 0, ppm = 0, toleranceRt = 0) {
 #'   for different adducts of the same compound. `query` must be a `data.frame`
 #'   with m/z and retention time values of the features. The names of the
 #'   columns containing these information can be specified with parameters
-#'   `mzColumn` and `rtColumn` which default to `"mz"` and `"rt"`,
+#'   `mzColname` and `rtColname` which default to `"mz"` and `"rt"`,
 #'   respectively). `target` must be a `data.frame` with the (monoisotopic)
 #'   mass and retention time for each compound. The names of the columns
-#'   containing these information can be specified with parameters `massColumn`
-#'   and `rtColumn` which default to `"exactmass"` and `"rt"`, respectively.
+#'   containing these information can be specified with parameters `massColname`
+#'   and `rtColname` which default to `"exactmass"` and `"rt"`, respectively.
 #'   `Mass2MzRtParam`'s parameter `adducts` allows to define the expected
 #'   adducts (defaults to `adducts = "[M+H]+"` but any adducts available in
 #'   [MetaboCoreUtils::adducts()] are supported). Parameter `tolerance` and
@@ -156,8 +156,8 @@ MzRtParam <- function(tolerance = 0, ppm = 0, toleranceRt = 0) {
 #'
 #' - `MzParam`: match m/z values against reference compounds for which the m/z
 #'   is known. `query` must be either a `data.frame` with a column containing
-#'   m/z values (which name can be specified with parameter `mzColumn`,
-#'   default being `mzColumn = "mz"`) or a `numeric` with the m/z values of
+#'   m/z values (which name can be specified with parameter `mzColname`,
+#'   default being `mzColname = "mz"`) or a `numeric` with the m/z values of
 #'   the features. The same holds for `target`. `MzParam` parameters
 #'   `tolerance` and `ppm` allow to define the maximal acceptable (constant or
 #'   m/z relative) difference between query and target m/z values.
@@ -168,7 +168,7 @@ MzRtParam <- function(tolerance = 0, ppm = 0, toleranceRt = 0) {
 #'   the `SummarizedExperiment` `rowData` in the other must have columns
 #'   containing the m/z and retention times of the
 #'   features. The names of the respective columns can be specified with
-#'   parameters `mzColumn` and `rtColumn` which default to `"mz"` and `"rt"`,
+#'   parameters `mzColname` and `rtColname` which default to `"mz"` and `"rt"`,
 #'   respectively.`target` must be a `data.frame` again with the information on
 #'   m/z and retention time.`MzRtParam` parameters `tolerance` and `ppm` allow
 #'   to define the maximal acceptable (constant or m/z relative) difference
@@ -184,11 +184,11 @@ MzRtParam <- function(tolerance = 0, ppm = 0, toleranceRt = 0) {
 #' @param BPPARAM parallel processing setup. See `BiocParallel::bpparam()` for
 #'     details.
 #'
-#' @param massColumn `character(1)` with the name of the column containing the
-#'     mass of compounds. Defaults to `massColumn = "exactmass"`.
+#' @param massColname `character(1)` with the name of the column containing the
+#'     mass of compounds. Defaults to `massColname = "exactmass"`.
 #'
-#' @param mzColumn `character(1)` with the name of the column containing the
-#'     m/z values. Defaults to `mzColumn = "mz"`.
+#' @param mzColname `character(1)` with the name of the column containing the
+#'     m/z values. Defaults to `mzColname = "mz"`.
 #'
 #' @param param parameter object defining the matching approach and containing
 #'     the settings for that approach. See description above for details.
@@ -197,8 +197,8 @@ MzRtParam <- function(tolerance = 0, ppm = 0, toleranceRt = 0) {
 #'     acceptable m/z-dependent difference (in parts-per-million) in m/z values
 #'     to consider them to be *matching*.
 #'
-#' @param rtColumn `character(1)` with the name of the column containing the
-#'     retention times of the compounds. Defaults to `rtColumn = "rt"`.
+#' @param rtColname `character(1)` with the name of the column containing the
+#'     retention times of the compounds. Defaults to `rtColname = "rt"`.
 #'
 #' @param target compound table with metabolites to compare against.
 #'
@@ -365,11 +365,11 @@ setMethod("matchMz",
           signature = c(query = "numeric",
                         target = "data.frameOrSimilar",
                         param = "Mass2MzParam"),
-          function(query, target, param, massColumn = "exactmass",
+          function(query, target, param, massColname = "exactmass",
                    BPPARAM = SerialParam()) {
-            if (!massColumn %in% colnames(target))
-              stop("Missing column \"", massColumn, "\" in target")
-            res <- matchMz(query, target[, massColumn], param)
+            if (!massColname %in% colnames(target))
+              stop("Missing column \"", massColname, "\" in target")
+            res <- matchMz(query, target[, massColname], param)
             res@target <- target
             res
           })
@@ -379,8 +379,8 @@ setMethod("matchMz",
                         target = "numeric",
                         param = "Mass2MzParam"),
           function(query, target, param, BPPARAM = SerialParam(),
-                   mzColumn = "mz") {
-            if (!mzColumn %in% colnames(query))
+                   mzColname = "mz") {
+            if (!mzColname %in% colnames(query))
               stop("Missing column \"mz\" in query")
             res <- matchMz(query$mz, target, param)
             res@query <- query
@@ -391,13 +391,13 @@ setMethod("matchMz",
           signature = c(query = "data.frameOrSimilar",
                         target = "data.frameOrSimilar",
                         param = "Mass2MzParam"),
-          function(query, target, param, mzColumn = "mz",
-                   massColumn = "exactmass", BPPARAM = SerialParam()) {
-            if (!mzColumn %in% colnames(query))
-              stop("Missing column \"", mzColumn, "\" in query")
-            if (!massColumn %in% colnames(target))
-              stop("Missing column \"", massColumn, "\" in target")
-            res <- matchMz(query[, mzColumn], target[, massColumn], param)
+          function(query, target, param, mzColname = "mz",
+                   massColname = "exactmass", BPPARAM = SerialParam()) {
+            if (!mzColname %in% colnames(query))
+              stop("Missing column \"", mzColname, "\" in query")
+            if (!massColname %in% colnames(target))
+              stop("Missing column \"", massColname, "\" in target")
+            res <- matchMz(query[, mzColname], target[, massColname], param)
             res@query <- query
             res@target <- target
             res
@@ -427,11 +427,11 @@ setMethod("matchMz",
           signature = c(query = "numeric",
                         target = "data.frameOrSimilar",
                         param = "MzParam"),
-          function(query, target, param, mzColumn = "mz",
+          function(query, target, param, mzColname = "mz",
                    BPPARAM = SerialParam()) {
-            if (!mzColumn %in% colnames(target))
-              stop("Missing column \"", mzColumn, "\" in target")
-            res <- matchMz(query, target[, mzColumn], param)
+            if (!mzColname %in% colnames(target))
+              stop("Missing column \"", mzColname, "\" in target")
+            res <- matchMz(query, target[, mzColname], param)
             res@target <- target
             res
           })
@@ -440,11 +440,11 @@ setMethod("matchMz",
           signature = c(query = "data.frameOrSimilar",
                         target = "numeric",
                         param = "MzParam"),
-          function(query, target, param, mzColumn = "mz",
+          function(query, target, param, mzColname = "mz",
                    BPPARAM = SerialParam()) {
-            if (!mzColumn %in% colnames(query))
-              stop("Missing column \"", mzColumn, "\" in query")
-            res <- matchMz(query[, mzColumn], target, param)
+            if (!mzColname %in% colnames(query))
+              stop("Missing column \"", mzColname, "\" in query")
+            res <- matchMz(query[, mzColname], target, param)
             res@query <- query
             res
           })
@@ -453,15 +453,15 @@ setMethod("matchMz",
           signature = c(query = "data.frameOrSimilar",
                         target = "data.frameOrSimilar",
                         param = "MzParam"),
-          function(query, target, param, mzColumn = c("mz", "mz"),
+          function(query, target, param, mzColname = c("mz", "mz"),
                    BPPARAM = SerialParam()) {
-            if(length(mzColumn) == 1)
-              mzColumn <- rep(mzColumn, 2)
-            if (!mzColumn[1] %in% colnames(query))
-              stop("Missing column \"", mzColumn[1], "\" in query")
-            if (!mzColumn[2] %in% colnames(target))
-              stop("Missing column \"", mzColumn[2], "\" in target")
-            res <- matchMz(query[, mzColumn[1]], target[, mzColumn[2]], param)
+            if(length(mzColname) == 1)
+              mzColname <- rep(mzColname, 2)
+            if (!mzColname[1] %in% colnames(query))
+              stop("Missing column \"", mzColname[1], "\" in query")
+            if (!mzColname[2] %in% colnames(target))
+              stop("Missing column \"", mzColname[2], "\" in target")
+            res <- matchMz(query[, mzColname[1]], target[, mzColname[2]], param)
             res@query <- query
             res@target <- target
             res
@@ -473,25 +473,25 @@ setMethod("matchMz",
           signature = c(query = "data.frameOrSimilar",
                         target = "data.frameOrSimilar",
                         param = "Mass2MzRtParam"),
-          function(query, target, param, massColumn = "exactmass",
-                   mzColumn = "mz", rtColumn = c("rt", "rt"),
+          function(query, target, param, massColname = "exactmass",
+                   mzColname = "mz", rtColname = c("rt", "rt"),
                    BPPARAM = SerialParam()) {
-            if(length(rtColumn) == 1)
-              rtColumn <- rep(rtColumn, 2)
-            if (!mzColumn %in% colnames(query))
-              stop("Missing column \"", mzColumn, "\" in query")
-            if (!rtColumn[1] %in% colnames(query))
-              stop("Missing column \"", rtColumn[1], "\" in query")
-            if (!massColumn %in% colnames(target))
-              stop("Missing column \"", massColumn, "\" in target")
-            if (!rtColumn[2] %in% colnames(target))
-              stop("Missing column \"", rtColumn[2], "\" in target")
-            target_mz <- .mass_to_mz_df(target[, massColumn], param@adducts)
-            target_mz$rt <- rep(target[, rtColumn[2]], length(param@adducts))
+            if(length(rtColname) == 1)
+              rtColname <- rep(rtColname, 2)
+            if (!mzColname %in% colnames(query))
+              stop("Missing column \"", mzColname, "\" in query")
+            if (!rtColname[1] %in% colnames(query))
+              stop("Missing column \"", rtColname[1], "\" in query")
+            if (!massColname %in% colnames(target))
+              stop("Missing column \"", massColname, "\" in target")
+            if (!rtColname[2] %in% colnames(target))
+              stop("Missing column \"", rtColname[2], "\" in target")
+            target_mz <- .mass_to_mz_df(target[, massColname], param@adducts)
+            target_mz$rt <- rep(target[, rtColname[2]], length(param@adducts))
             queryl <- nrow(query)
             matches <- vector("list", queryl)
-            query_mz <- query[, mzColumn]
-            query_rt <- query[, rtColumn[1L]]
+            query_mz <- query[, mzColname]
+            query_rt <- query[, rtColname[1L]]
             for (i in seq_len(queryl)) {
                 matches[[i]] <- .getMatchesMzRt(i, query_mz[i], query_rt[i],
                                                 target = target_mz,
@@ -509,27 +509,27 @@ setMethod("matchMz",
           signature = c(query = "data.frameOrSimilar",
                         target = "data.frameOrSimilar",
                         param = "MzRtParam"),
-          function(query, target, param, mzColumn = c("mz", "mz"),
-                   rtColumn = c("rt", "rt"), BPPARAM = SerialParam()) {
-            if(length(mzColumn) == 1)
-              mzColumn <- rep(mzColumn, 2)
-            if(length(rtColumn) == 1)
-              rtColumn <- rep(rtColumn, 2)
-            if (!mzColumn[1] %in% colnames(query))
-              stop("Missing column \"", mzColumn[1], "\" in query")
-            if (!mzColumn[2] %in% colnames(target))
-              stop("Missing column \"", mzColumn[2], "\" in target")
-            if (!rtColumn[1] %in% colnames(query))
-              stop("Missing column \"", rtColumn[1], "\" in query")
-            if (!rtColumn[2] %in% colnames(target))
-              stop("Missing column \"", rtColumn[2], "\" in target")
+          function(query, target, param, mzColname = c("mz", "mz"),
+                   rtColname = c("rt", "rt"), BPPARAM = SerialParam()) {
+            if(length(mzColname) == 1)
+              mzColname <- rep(mzColname, 2)
+            if(length(rtColname) == 1)
+              rtColname <- rep(rtColname, 2)
+            if (!mzColname[1] %in% colnames(query))
+              stop("Missing column \"", mzColname[1], "\" in query")
+            if (!mzColname[2] %in% colnames(target))
+              stop("Missing column \"", mzColname[2], "\" in target")
+            if (!rtColname[1] %in% colnames(query))
+              stop("Missing column \"", rtColname[1], "\" in query")
+            if (!rtColname[2] %in% colnames(target))
+              stop("Missing column \"", rtColname[2], "\" in target")
             target_mz <- data.frame(index = seq_len(nrow(target)),
-                                    mz = target[, mzColumn[2]],
-                                    rt = target[, rtColumn[2]])
+                                    mz = target[, mzColname[2]],
+                                    rt = target[, rtColname[2]])
             queryl <- nrow(query)
             matches <- vector("list", queryl)
-            query_mz <- query[, mzColumn[1L]]
-            query_rt <- query[, rtColumn[1L]]
+            query_mz <- query[, mzColname[1L]]
+            query_rt <- query[, rtColname[1L]]
             for (i in seq_len(queryl)) {
                 matches[[i]] <- .getMatchesMzRt(i, query_mz[i],
                                                 query_rt[i],
@@ -547,10 +547,10 @@ setMethod("matchMz",
           signature = c(query = "SummarizedExperiment",
                         target = "ANY",
                         param = "Param"),
-          function(query, target, param, mzColumn = "mz", rtColumn = "rt",
+          function(query, target, param, mzColname = "mz", rtColname = "rt",
                    BPPARAM = SerialParam()) {
             matches <- matchMz(data.frame(rowData(query)), target, param,
-                               mzColumn , rtColumn, BPPARAM)@matches
+                               mzColname , rtColname, BPPARAM)@matches
             MatchedSummarizedExperiment(query, target, matches)
           })
 

--- a/man/Matched.Rd
+++ b/man/Matched.Rd
@@ -118,7 +118,7 @@ variables that should be extracted.}
 \item{queryValue}{for \code{filterMatches}: vector of values to search for in
 \code{query} (if \code{query} is 1-dimensional) or in column \code{queryColname} of
 \code{query} (if \code{query} is 2-dimensional). For \code{addMatches}: either an index
-in \code{query} or value in column \code{queryColumn} of \code{query} defining (together
+in \code{query} or value in column \code{queryColname} of \code{query} defining (together
 with \code{targetValue}) the pair of query and target elements for which a
 match should be manually added. Lengths of \code{queryValue} and
 \code{targetValue} have to match.}
@@ -126,7 +126,7 @@ match should be manually added. Lengths of \code{queryValue} and
 \item{targetValue}{for \code{filterMatches}: vector of values to search for in
 \code{target} (if \code{target} is 1-dimensional) or in column \code{targetColname} of
 \code{target} (if \code{target} is 2-dimensional). For \code{addMatches}: either an
-index in \code{target} or value in column \code{targetColumn} of \code{target} defining
+index in \code{target} or value in column \code{targetColname} of \code{target} defining
 (together with \code{queryValue}) the pair of query and target elements for
 which a match should be manually added. Lengths of \code{queryValue} and
 \code{targetValue} have to match.}
@@ -194,8 +194,8 @@ returned as-is.
 both \code{queryValue} and \code{targetValue} are considered to be integer indices
 identifying the matching elements in \code{query} and \code{target}, respectively.
 Alternatively (with \code{isIndex = FALSE}) \code{queryValue} and \code{targetValue} can
-be elements in columns \code{queryColumn} or \code{targetColumn} which can be used to
-identify the matching elements. Note that in this case
+be elements in columns \code{queryColname} or \code{targetColname} which can be used
+to identify the matching elements. Note that in this case
 \strong{only the first} matching pair is added. Parameter \code{score} allows to
 provide the score for the match. It can be a numeric with the score or a
 \code{data.frame} with additional information on the manually added matches. In

--- a/man/matchMz.Rd
+++ b/man/matchMz.Rd
@@ -35,32 +35,32 @@ matchMz(query, target, param, ...)
   query,
   target,
   param,
-  massColumn = "exactmass",
+  massColname = "exactmass",
   BPPARAM = SerialParam()
 )
 
-\S4method{matchMz}{data.frameOrSimilar,numeric,Mass2MzParam}(query, target, param, BPPARAM = SerialParam(), mzColumn = "mz")
+\S4method{matchMz}{data.frameOrSimilar,numeric,Mass2MzParam}(query, target, param, BPPARAM = SerialParam(), mzColname = "mz")
 
 \S4method{matchMz}{data.frameOrSimilar,data.frameOrSimilar,Mass2MzParam}(
   query,
   target,
   param,
-  mzColumn = "mz",
-  massColumn = "exactmass",
+  mzColname = "mz",
+  massColname = "exactmass",
   BPPARAM = SerialParam()
 )
 
 \S4method{matchMz}{numeric,numeric,MzParam}(query, target, param, BPPARAM = SerialParam())
 
-\S4method{matchMz}{numeric,data.frameOrSimilar,MzParam}(query, target, param, mzColumn = "mz", BPPARAM = SerialParam())
+\S4method{matchMz}{numeric,data.frameOrSimilar,MzParam}(query, target, param, mzColname = "mz", BPPARAM = SerialParam())
 
-\S4method{matchMz}{data.frameOrSimilar,numeric,MzParam}(query, target, param, mzColumn = "mz", BPPARAM = SerialParam())
+\S4method{matchMz}{data.frameOrSimilar,numeric,MzParam}(query, target, param, mzColname = "mz", BPPARAM = SerialParam())
 
 \S4method{matchMz}{data.frameOrSimilar,data.frameOrSimilar,MzParam}(
   query,
   target,
   param,
-  mzColumn = c("mz", "mz"),
+  mzColname = c("mz", "mz"),
   BPPARAM = SerialParam()
 )
 
@@ -68,9 +68,9 @@ matchMz(query, target, param, ...)
   query,
   target,
   param,
-  massColumn = "exactmass",
-  mzColumn = "mz",
-  rtColumn = c("rt", "rt"),
+  massColname = "exactmass",
+  mzColname = "mz",
+  rtColname = c("rt", "rt"),
   BPPARAM = SerialParam()
 )
 
@@ -78,8 +78,8 @@ matchMz(query, target, param, ...)
   query,
   target,
   param,
-  mzColumn = c("mz", "mz"),
-  rtColumn = c("rt", "rt"),
+  mzColname = c("mz", "mz"),
+  rtColname = c("rt", "rt"),
   BPPARAM = SerialParam()
 )
 
@@ -87,8 +87,8 @@ matchMz(query, target, param, ...)
   query,
   target,
   param,
-  mzColumn = "mz",
-  rtColumn = "rt",
+  mzColname = "mz",
+  rtColname = "rt",
   BPPARAM = SerialParam()
 )
 }
@@ -124,14 +124,14 @@ the settings for that approach. See description above for details.}
 \item{BPPARAM}{parallel processing setup. See \code{BiocParallel::bpparam()} for
 details.}
 
-\item{massColumn}{\code{character(1)} with the name of the column containing the
-mass of compounds. Defaults to \code{massColumn = "exactmass"}.}
+\item{massColname}{\code{character(1)} with the name of the column containing the
+mass of compounds. Defaults to \code{massColname = "exactmass"}.}
 
-\item{mzColumn}{\code{character(1)} with the name of the column containing the
-m/z values. Defaults to \code{mzColumn = "mz"}.}
+\item{mzColname}{\code{character(1)} with the name of the column containing the
+m/z values. Defaults to \code{mzColname = "mz"}.}
 
-\item{rtColumn}{\code{character(1)} with the name of the column containing the
-retention times of the compounds. Defaults to \code{rtColumn = "rt"}.}
+\item{rtColname}{\code{character(1)} with the name of the column containing the
+retention times of the compounds. Defaults to \code{rtColname = "rt"}.}
 }
 \value{
 \link{Matched} object representing the result
@@ -150,11 +150,11 @@ which the (exact) mass is known. Before matching, m/z values are calculated
 from the mass of the compounds in the \emph{target} table for the specified
 adducts (parameter \code{adduct} in the parameter object).
 \code{query} must be a \code{data.frame} with a column containing m/z values (column
-name can be specified with parameter \code{mzColumn} which defaults to \code{"mz"})
+name can be specified with parameter \code{mzColname} which defaults to \code{"mz"})
 or a \code{numeric} with the m/z values of the features.
 If \code{target} is a \code{data.frame} it must
 contain a column with the (monoisotopic) mass of the compounds (the column
-name can be specified with parameter \code{massColumn} which defaults to
+name can be specified with parameter \code{massColname} which defaults to
 \code{"exactmass"}) \code{Mass2MzParam}'s parameter \code{adducts} allows to define
 the expected adducts (defaults to \code{adducts = "[M+H]+"} but any adducts
 available in \code{\link[MetaboCoreUtils:adductNames]{MetaboCoreUtils::adducts()}} are supported). Parameter
@@ -168,11 +168,11 @@ compounds in the \emph{target} table for the specified adducts (parameter
 for different adducts of the same compound. \code{query} must be a \code{data.frame}
 with m/z and retention time values of the features. The names of the
 columns containing these information can be specified with parameters
-\code{mzColumn} and \code{rtColumn} which default to \code{"mz"} and \code{"rt"},
+\code{mzColname} and \code{rtColname} which default to \code{"mz"} and \code{"rt"},
 respectively). \code{target} must be a \code{data.frame} with the (monoisotopic)
 mass and retention time for each compound. The names of the columns
-containing these information can be specified with parameters \code{massColumn}
-and \code{rtColumn} which default to \code{"exactmass"} and \code{"rt"}, respectively.
+containing these information can be specified with parameters \code{massColname}
+and \code{rtColname} which default to \code{"exactmass"} and \code{"rt"}, respectively.
 \code{Mass2MzRtParam}'s parameter \code{adducts} allows to define the expected
 adducts (defaults to \code{adducts = "[M+H]+"} but any adducts available in
 \code{\link[MetaboCoreUtils:adductNames]{MetaboCoreUtils::adducts()}} are supported). Parameter \code{tolerance} and
@@ -182,8 +182,8 @@ allows to specify the maximal acceptable difference between query and
 target retention time values.
 \item \code{MzParam}: match m/z values against reference compounds for which the m/z
 is known. \code{query} must be either a \code{data.frame} with a column containing
-m/z values (which name can be specified with parameter \code{mzColumn},
-default being \code{mzColumn = "mz"}) or a \code{numeric} with the m/z values of
+m/z values (which name can be specified with parameter \code{mzColname},
+default being \code{mzColname = "mz"}) or a \code{numeric} with the m/z values of
 the features. The same holds for \code{target}. \code{MzParam} parameters
 \code{tolerance} and \code{ppm} allow to define the maximal acceptable (constant or
 m/z relative) difference between query and target m/z values.
@@ -193,7 +193,7 @@ compounds for which m/z and retention time are known. \code{query} must be a
 the \code{SummarizedExperiment} \code{rowData} in the other must have columns
 containing the m/z and retention times of the
 features. The names of the respective columns can be specified with
-parameters \code{mzColumn} and \code{rtColumn} which default to \code{"mz"} and \code{"rt"},
+parameters \code{mzColname} and \code{rtColname} which default to \code{"mz"} and \code{"rt"},
 respectively.\code{target} must be a \code{data.frame} again with the information on
 m/z and retention time.\code{MzRtParam} parameters \code{tolerance} and \code{ppm} allow
 to define the maximal acceptable (constant or m/z relative) difference

--- a/tests/testthat/test_matchMz.R
+++ b/tests/testthat/test_matchMz.R
@@ -277,10 +277,10 @@ test_that("matchMz, MzRtParam works", {
   library(SummarizedExperiment)
   qry <- SummarizedExperiment(
     assays = data.frame(matrix(NA, 4, 2)),
-    colData = data.frame(cD1 = c(NA, NA), cD2 = c(NA, NA)), 
+    colData = data.frame(cD1 = c(NA, NA), cD2 = c(NA, NA)),
     rowData = data.frame(mz = c(13, 14.1, 17, 18), rt = c(23, 24, 26.8, 23)))
   trgt <- data.frame(mz = 11:17, rt = 21:27)
-  
+
   par <- MzRtParam(tolerance = 0, ppm = 0, toleranceRt = 0)
   res <- matchMz(qry, trgt, par)
   expect_equal(query(res), qry)
@@ -289,21 +289,21 @@ test_that("matchMz, MzRtParam works", {
   expect_equal(res@matches$target_idx, c(3))
   expect_equal(res@matches$score, c(0))
   expect_equal(res@matches$score_rt, c(0))
-  
+
   par <- MzRtParam(tolerance = 0.1, ppm = 0, toleranceRt = 0)
   res <- matchMz(qry, trgt, par)
   expect_equal(res@matches$query_idx, c(1, 2))
   expect_equal(res@matches$target_idx, c(3, 4))
   expect_equal(res@matches$score, c(0, 0.1))
   expect_equal(res@matches$score_rt, c(0, 0))
-  
+
   par <- MzRtParam(tolerance = 0.1, ppm = 0, toleranceRt = 0.2)
   res <- matchMz(qry, trgt, par)
   expect_equal(res@matches$query_idx, c(1, 2, 3))
   expect_equal(res@matches$target_idx, c(3, 4, 7))
   expect_equal(res@matches$score, c(0, 0.1, 0))
   expect_equal(res@matches$score_rt, c(0, 0, 0.2))
-  
+
   ## no matches
   res <- matchMz(qry , trgt + 0.5, par)
   expect_true(is(res, "Matched"))

--- a/vignettes/MetaboAnnotation.Rmd
+++ b/vignettes/MetaboAnnotation.Rmd
@@ -170,14 +170,14 @@ in retention times. We use the settings from the previous section and allow a
 difference of 10 seconds in retention times. The retention times are provided in
 columns named `"rtime"` which is different from the default (`"rt"`). We thus
 specify the name of the column containing the retention times with parameter
-`rtColumn`.
+`rtColname`.
 
 ```{r}
 parm <- Mass2MzRtParam(adducts = c("[M+H]+", "[M+Na]+"),
                        tolerance = 0.005, ppm = 0,
                        toleranceRt = 10)
 matched_features <- matchMz(ms1_subset, target_df, param = parm,
-                            rtColumn = "rtime")
+                            rtColname = "rtime")
 matched_features
 ```
 


### PR DESCRIPTION
- Improve the performance of the `matchMz` method (issue #28 ).
- Rename `*Column` parameters to `*Colname` (issue #32).