### PR TITLE
refactor: plotly: use segments instead of bars

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboAnnotation
 Title: Utilities for Annotation of Metabolomics Data
-Version: 0.99.11
+Version: 0.99.12
 Description:
     High level functions to assist in annotation of (metabolomics) data sets.
     These include functions to perform simple tentative annotations based on

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # MetaboAnnotation 0.99
 
+## Changes in 0.99.12
+
+- Update plotly-based mirror plots in `validateMatchedSpectra`.
+
 ## Changes in 0.99.11
 
 - Change `matchMz` into `matchValues` (issue


### PR DESCRIPTION
- Draw spectra as segments rather than as bars.