### PR TITLE
Issue #69 fixed.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboAnnotation
 Title: Utilities for Annotation of Metabolomics Data
-Version: 0.99.12
+Version: 0.99.13
 Description:
     High level functions to assist in annotation of (metabolomics) data sets.
     These include functions to perform simple tentative annotations based on

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # MetaboAnnotation 0.99
 
+## Changes in 0.99.13
+
+- Fix issue about `matchedData` not working for result objects of
+  `matchValues, Mz2MassParam` and `matchValues, Mz2MassRtParam` (issue
+  [#69](https://github.com/rformassspectrometry/MetaboAnnotation/issues/69)).
+
 ## Changes in 0.99.12
 
 - Update plotly-based mirror plots in `validateMatchedSpectra`.

--- a/R/Matched.R
+++ b/R/Matched.R
@@ -661,16 +661,23 @@ setMethod("matchedData", "Matched", function(object,
     msg
 }
 
+.cnt <- function(target) {
+    ndim <- length(dim(target))
+    if (ndim == 2) {
+        cnt <- colnames(target)
+        if (length(cnt)) cnt <- paste0("target_", cnt)
+    } else if (ndim == 0) {
+        cnt <- "target"
+    } else {
+        stop("unsupported dimensions in \"target\"")
+    }
+    cnt
+}
+
 .colnames <- function(query, target, matches) {
   cns <- colnames(matches)
   cnq <- NULL
-  cnt <- NULL
-  if (length(dim(target)) == 2){
-    cnt <- colnames(target)
-    if (length(cnt)) cnt <- paste0("target_", cnt)
-  }
-  if (is.null(dim(target)))
-    cnt <- "target"
+  cnt <- .cnt(target)
   if (length(dim(query)) == 2)
     cnq <- colnames(query)
   if (is.null(dim(query)))
@@ -688,7 +695,7 @@ setMethod("matchedData", "Matched", function(object,
       idxs_mtch <- c(seq_len(nrow(matches)), rep(NA, length(not_mtchd)))[ord]
       return(matches[idxs_mtch, name])
     }
-    if (name == "target" || length(grep("^target_", name))) {
+    if (name %in% .cnt(target)) {
       idxs_trg <- c(matches$target_idx, rep(NA, length(not_mtchd)))[ord]
       .extract_elements(target, idxs_trg, sub("target_", "", name), drop = TRUE)
     }else
@@ -704,7 +711,7 @@ setMethod("matchedData", "Matched", function(object,
   not_mtchd <- setdiff(seq_len(.nelements(query)), matches$query_idx)
   idxs_qry <- c(matches$query_idx, not_mtchd)
   ord <- order(idxs_qry)
-  from_target <- grepl("^target_", columns) | columns == "target"
+  from_target <- columns %in% .cnt(target)
   from_matches <- columns %in% colnames(matches)
   from_query <- !(from_target | from_matches)
   res_q <- NULL

--- a/tests/testthat/test_Matched.R
+++ b/tests/testthat/test_Matched.R
@@ -570,3 +570,14 @@ test_that(".extract_elements works", {
     expect_equal(.extract_elements(a, c(3, 6)), list(3, NULL))
     expect_equal(.extract_elements(a, c(NA, 1)), list(NA, 1))
 })
+
+test_that(".cnt works", {
+    t <- data.frame(a = 1:5, b = 2:6)
+    expect_equal(.cnt(t), c("target_a", "target_b"))
+    
+    t <- 1:5
+    expect_equal(.cnt(t), "target")
+
+    t <- array(data = 1, dim = c(1, 1, 1))
+    expect_error(.cnt(t), "unsupported")
+})

--- a/tests/testthat/test_matchValues.R
+++ b/tests/testthat/test_matchValues.R
@@ -556,6 +556,7 @@ test_that("matchValues, Mz2MassParam works", {
     expect_equal(query(res), qry)
     expect_equal(target(res), data.frame(mz = trgt))
     expect_equal(res@metadata$param, par)
+    expect_true(is(matchedData(res), "DataFrame"))
 
     ## data.frame, numeric
     expect_error(
@@ -661,6 +662,7 @@ test_that("matchValues, Mz2MassRtParam works", {
     expect_equal(res@matches$score, c(0, 0))
     expect_equal(res@matches$ppm_error, c(0, 0))
     expect_equal(res@matches$score_rt, c(0, 0))
+    expect_true(is(matchedData(res), "DataFrame"))
 
     ## positive toleranceRt
     par <- Mz2MassRtParam(queryAdducts = c("[M+H]+", "[M+K]+"),


### PR DESCRIPTION
`matchedData` was not working for result objects of `matchValues, Mz2MassParam` and `matchValues, Mz2MassRtParam` because of the `target_` prefix in `target_adducts`. `target_adducts` was interpreted as a variable from `target`.