### PR TITLE
Fix: keep structure if only one adduct

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboAnnotation
 Title: Utilities for Annotation of Metabolomics Data
-Version: 1.5.7
+Version: 1.5.8
 Description:
     High level functions to assist in annotation of (metabolomics) data sets.
     These include functions to perform simple tentative annotations based on

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,15 @@
 # MetaboAnnotation 1.5
 
+## Changes in 1.5.8 
+
+- Fix `.randomize_grouping` to prevent collapsing of matrix when input in a
+  single column
+
 ## Changes in 1.5.7
 
-- Add function `.group_standards_iteration` and `.randomize_grouping` to allow iteration through matrix 
-  of standards and group them if they are dissimilar enough.
+- Add function `.group_standards_iteration` and `.randomize_grouping` to allow
+  iteration through matrix of standards and group them if they are dissimilar
+  enough.
 
 ## Changes in 1.5.6
 

--- a/R/group_standards.R
+++ b/R/group_standards.R
@@ -118,7 +118,7 @@
                                                       max_nstd = max_nstd,
                                                       min_diff = min_diff)
         if (i > n*n)
-            stop("all combination were tested, no possibility to fit your input requirement")
+            stop("all combination were tested, no possibility to fit your input requirements")
     }  
     standard_groups
 }

--- a/man/matchValues.Rd
+++ b/man/matchValues.Rd
@@ -200,13 +200,13 @@ difference (in parts-per-million) in m/z values to consider them to
 be \emph{matching}.}
 
 \item{adducts}{for \code{Mass2MzParam} or \code{Mass2MzRtParam}: either \code{character}
-with adduct names from \code{\link[MetaboCoreUtils:adducts]{MetaboCoreUtils::adducts()}} or \code{data.frame} with
+with adduct names from \code{\link[MetaboCoreUtils:adductNames]{MetaboCoreUtils::adducts()}} or \code{data.frame} with
 a custom adduct definition. This parameter is used to calculate m/z from
 target compounds' masses. Custom adduct definitions can be passed to the
 adduct parameter in form of a \code{data.frame}. This \code{data.frame} is expected
 to have columns \code{"mass_add"} and \code{"mass_multi"} defining the \emph{additive}
 and \emph{multiplicative} part of the calculation. See
-\code{\link[MetaboCoreUtils:adducts]{MetaboCoreUtils::adducts()}} for the expected format or use
+\code{\link[MetaboCoreUtils:adductNames]{MetaboCoreUtils::adducts()}} for the expected format or use
 \code{MetaboCoreUtils::adductNames("positive")} and
 \code{MetaboCoreUtils::adductNames("negative")} for valid adduct names.}
 


### PR DESCRIPTION
Needed to retrain the matrix structure that drops if the code is ran with only one adduct. 