### PR TITLE
Fix reverse scoring in forward-reverse scoring with GNPS-like similarity scores

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 trim_trailing_whitespace = true
-insert_final_newline = false
+insert_final_newline = true
 
 [*.R]
 indent_style = space

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboAnnotation
 Title: Utilities for Annotation of Metabolomics Data
-Version: 1.11.0
+Version: 1.11.1
 Description:
     High level functions to assist in annotation of (metabolomics) data sets.
     These include functions to perform simple tentative annotations based on
@@ -71,6 +71,7 @@ URL: https://github.com/RforMassSpectrometry/MetaboAnnotation
 biocViews: Infrastructure, Metabolomics, MassSpectrometry
 Roxygen: list(markdown=TRUE)
 RoxygenNote: 7.3.2
+Encoding: UTF-8
 Collate:
     'AllClassUnions.R'
     'AllGenerics.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboAnnotation
 Title: Utilities for Annotation of Metabolomics Data
-Version: 1.10.0
+Version: 1.11.0
 Description:
     High level functions to assist in annotation of (metabolomics) data sets.
     These include functions to perform simple tentative annotations based on

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboAnnotation
 Title: Utilities for Annotation of Metabolomics Data
-Version: 1.9.2
+Version: 1.10.0
 Description:
     High level functions to assist in annotation of (metabolomics) data sets.
     These include functions to perform simple tentative annotations based on

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# MetaboAnnotation 1.11
+
+## Changes in 1.11.1
+
+- Fix reporting of matched peaks with `MatchForwardReverseParam` and
+  *gnps*-matching/similarity calculation (issue
+  [#119](https://github.com/rformassspectrometry/MetaboAnnotation/issues/119)).
+
 # MetaboAnnotation 1.9
 
 ## Changes in 1.9.2

--- a/R/matchSpectra.R
+++ b/R/matchSpectra.R
@@ -576,10 +576,14 @@ setMethod(
         res@matches$matched_peaks_count <- rep(NA_real_, nm)
         parms_rv <- .compare_spectra_parms_list(param)
         parms_rv$type <- "right"
+        query_pmz <- precursorMz(query)
+        target_pmz <- precursorMz(target)
         for (i in seq_len(nm)) {
             spl <- c(
                 list(x = peaksData(query[res@matches$query_idx[i]])[[1L]],
-                     y = peaksData(target[res@matches$target_idx[i]])[[1L]]),
+                     y = peaksData(target[res@matches$target_idx[i]])[[1L]],
+                     xPrecursorMz = query_pmz[res@matches$query_idx[i]],
+                     yPrecursorMz = target_pmz[res@matches$target_idx[i]]),
                 parms_rv)
             map <- do.call(param@MAPFUN, spl)
             spl$x <- map$x

--- a/tests/testthat/test_matchSpectra.R
+++ b/tests/testthat/test_matchSpectra.R
@@ -216,6 +216,35 @@ test_that("matchSpectra,MatchForwardReverseParam works", {
     res_2 <- matchSpectra(pest_ms2, minimb, mp)
     expect_true(all(res_2@matches$reverse_score > 0.9))
     expect_equal(unique(res_2@matches$query_idx), c(2, 4, 8))
+
+    a <- data.frame(
+        precursorMz = c(623.1618, 609.1825)
+    )
+    a$mz <- list(
+        c(300.0276, 315.0511),
+        c(242.0585, 286.0483, 301.0718)
+    )
+    a$intensity <- list(
+        c(20, 100),
+        c(1, 10, 100)
+    )
+    s <- Spectra(a)
+    res <- matchSpectra(
+        s[1], s[2],
+        param =  MatchForwardReverseParam(
+            requirePrecursor = FALSE, tolerance = 0.01,
+            THRESHFUN = function(x) which(x >= 0),
+            MAPFUN = joinPeaksGnps, FUN = MsCoreUtils::gnps))
+    expect_equal(res@matches$matched_peaks_count, 2)
+    ## Check that res@matches is not all 0
+
+    res <- matchSpectra(
+        s[1], s[2],
+        param =  MatchForwardReverseParam(
+            requirePrecursor = FALSE, tolerance = 1.1,
+            THRESHFUN = function(x) which(x >= 0)))
+    expect_equal(res@matches$matched_peaks_count, 1)
+    expect_equal(res@matches$presence_ratio, 1/3)
 })
 
 test_that("matchSpectra,Spectra,CompDb works", {


### PR DESCRIPTION
Pass the precursor m/z to the reverse similarity calculation scoring.